### PR TITLE
Always return after error during processing

### DIFF
--- a/internal/provider/product_data_source.go
+++ b/internal/provider/product_data_source.go
@@ -77,6 +77,7 @@ func (d productDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourceReq
 		resp.Diagnostics.AddError(
 			"Could not Retrieve Resource",
 			"The id field could not be parsed into an integer")
+		return
 	}
 
 	apiResp, err := d.provider.client.ProductsRetrieveWithResponse(ctx, idNumber, &dd.ProductsRetrieveParams{})

--- a/internal/provider/product_resource.go
+++ b/internal/provider/product_resource.go
@@ -104,6 +104,7 @@ func (r productResource) Create(ctx context.Context, req tfsdk.CreateResourceReq
 			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
 				fmt.Sprintf("\n\nbody:\n\n%s", body),
 		)
+		return
 	}
 
 	// write logs using the tflog package
@@ -129,6 +130,7 @@ func (r productResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 		resp.Diagnostics.AddError(
 			"Could not Retrieve Resource",
 			"The Id field was null but it is required to retrieve the product")
+		return
 	}
 
 	idNumber, err := strconv.Atoi(data.Id.Value)
@@ -136,6 +138,7 @@ func (r productResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 		resp.Diagnostics.AddError(
 			"Could not Retrieve Resource",
 			fmt.Sprintf("Error while parsing the Product ID from state: %s", err))
+		return
 	}
 
 	apiResp, err := r.provider.client.ProductsRetrieveWithResponse(ctx, idNumber, &dd.ProductsRetrieveParams{})
@@ -158,6 +161,7 @@ func (r productResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
 				fmt.Sprintf("\n\nbody:\n\n%+v", body),
 		)
+		return
 	}
 
 	diags = resp.State.Set(ctx, &data)
@@ -178,6 +182,7 @@ func (r productResource) Update(ctx context.Context, req tfsdk.UpdateResourceReq
 		resp.Diagnostics.AddError(
 			"Could not Update Resource",
 			"The Id field was null but it is required to retrieve the product")
+		return
 	}
 
 	idNumber, err := strconv.Atoi(data.Id.Value)
@@ -185,6 +190,7 @@ func (r productResource) Update(ctx context.Context, req tfsdk.UpdateResourceReq
 		resp.Diagnostics.AddError(
 			"Could not Update Resource",
 			fmt.Sprintf("Error while parsing the Product ID from state: %s", err))
+		return
 	}
 
 	apiResp, err := r.provider.client.ProductsUpdateWithResponse(ctx, idNumber, dd.ProductsUpdateJSONRequestBody{
@@ -213,6 +219,7 @@ func (r productResource) Update(ctx context.Context, req tfsdk.UpdateResourceReq
 			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
 				fmt.Sprintf("\n\nbody:\n\n%+v", body),
 		)
+		return
 	}
 
 	diags = resp.State.Set(ctx, &data)
@@ -233,6 +240,7 @@ func (r productResource) Delete(ctx context.Context, req tfsdk.DeleteResourceReq
 		resp.Diagnostics.AddError(
 			"Could not Delete Resource",
 			"The Id field was null but it is required to retrieve the product")
+		return
 	}
 
 	idNumber, err := strconv.Atoi(data.Id.Value)
@@ -240,6 +248,7 @@ func (r productResource) Delete(ctx context.Context, req tfsdk.DeleteResourceReq
 		resp.Diagnostics.AddError(
 			"Could not Delete Resource",
 			fmt.Sprintf("Error while parsing the Product ID from state: %s", err))
+		return
 	}
 
 	apiResp, err := r.provider.client.ProductsDestroy(ctx, idNumber)
@@ -258,6 +267,7 @@ func (r productResource) Delete(ctx context.Context, req tfsdk.DeleteResourceReq
 			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode)+
 				fmt.Sprintf("\n\nbody:\n\n%+v", body),
 		)
+		return
 	}
 
 	resp.State.RemoveResource(ctx)

--- a/internal/provider/product_type_data_source.go
+++ b/internal/provider/product_type_data_source.go
@@ -99,11 +99,13 @@ func (d productTypeDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourc
 			resp.Diagnostics.AddError(
 				"Could not Retrieve Data Resource",
 				"No Product Types matched the given parameters.")
+			return
 		} else if *apiResp.JSON200.Count > 1 {
 			body, _ := ioutil.ReadAll(apiResp.HTTPResponse.Body)
 			resp.Diagnostics.AddError(
 				"Could not Retrieve Data Resource",
 				fmt.Sprintf("%d Product Types matched the given parameters.\n\nResponse:\n\n%s", *apiResp.JSON200.Count, body))
+			return
 		} else {
 			pt = (*apiResp.JSON200.Results)[0]
 
@@ -119,6 +121,7 @@ func (d productTypeDataSource) Read(ctx context.Context, req tfsdk.ReadDataSourc
 			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
 				fmt.Sprintf("\n\nbody:\n\n%+v", body),
 		)
+		return
 	}
 
 	diags = resp.State.Set(ctx, &data)

--- a/internal/provider/product_type_resource.go
+++ b/internal/provider/product_type_resource.go
@@ -96,6 +96,7 @@ func (r productTypeResource) Create(ctx context.Context, req tfsdk.CreateResourc
 			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
 				fmt.Sprintf("\n\nbody:\n\n%s", body),
 		)
+		return
 	}
 
 	// write logs using the tflog package
@@ -121,6 +122,7 @@ func (r productTypeResource) Read(ctx context.Context, req tfsdk.ReadResourceReq
 		resp.Diagnostics.AddError(
 			"Could not Retrieve Resource",
 			"The Id field was null but it is required to retrieve the product type")
+		return
 	}
 
 	idNumber, err := strconv.Atoi(data.Id.Value)
@@ -128,6 +130,7 @@ func (r productTypeResource) Read(ctx context.Context, req tfsdk.ReadResourceReq
 		resp.Diagnostics.AddError(
 			"Could not Retrieve Resource",
 			fmt.Sprintf("Error while parsing the Product Type ID from state: %s", err))
+		return
 	}
 
 	apiResp, err := r.provider.client.ProductTypesRetrieveWithResponse(ctx, idNumber, &dd.ProductTypesRetrieveParams{})
@@ -149,6 +152,7 @@ func (r productTypeResource) Read(ctx context.Context, req tfsdk.ReadResourceReq
 			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
 				fmt.Sprintf("\n\nbody:\n\n%+v", body),
 		)
+		return
 	}
 
 	diags = resp.State.Set(ctx, &data)
@@ -169,6 +173,7 @@ func (r productTypeResource) Update(ctx context.Context, req tfsdk.UpdateResourc
 		resp.Diagnostics.AddError(
 			"Could not Update Resource",
 			"The Id field was null but it is required to retrieve the product")
+		return
 	}
 
 	idNumber, err := strconv.Atoi(data.Id.Value)
@@ -176,6 +181,7 @@ func (r productTypeResource) Update(ctx context.Context, req tfsdk.UpdateResourc
 		resp.Diagnostics.AddError(
 			"Could not Update Resource",
 			fmt.Sprintf("Error while parsing the Product Type ID from state: %s", err))
+		return
 	}
 
 	apiResp, err := r.provider.client.ProductTypesUpdateWithResponse(ctx, idNumber, dd.ProductTypesUpdateJSONRequestBody{
@@ -202,6 +208,7 @@ func (r productTypeResource) Update(ctx context.Context, req tfsdk.UpdateResourc
 			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
 				fmt.Sprintf("\n\nbody:\n\n%+v", body),
 		)
+		return
 	}
 
 	diags = resp.State.Set(ctx, &data)
@@ -222,6 +229,7 @@ func (r productTypeResource) Delete(ctx context.Context, req tfsdk.DeleteResourc
 		resp.Diagnostics.AddError(
 			"Could not Delete Resource",
 			"The Id field was null but it is required to retrieve the product type")
+		return
 	}
 
 	idNumber, err := strconv.Atoi(data.Id.Value)
@@ -229,6 +237,7 @@ func (r productTypeResource) Delete(ctx context.Context, req tfsdk.DeleteResourc
 		resp.Diagnostics.AddError(
 			"Could not Delete Resource",
 			fmt.Sprintf("Error while parsing the Product Type ID from state: %s", err))
+		return
 	}
 
 	apiResp, err := r.provider.client.ProductTypesDestroy(ctx, idNumber)
@@ -247,6 +256,7 @@ func (r productTypeResource) Delete(ctx context.Context, req tfsdk.DeleteResourc
 			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode)+
 				fmt.Sprintf("\n\nbody:\n\n%+v", body),
 		)
+		return
 	}
 
 	resp.State.RemoveResource(ctx)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -49,6 +49,10 @@ func (p *provider) Configure(ctx context.Context, req tfsdk.ConfigureProviderReq
 		return
 	}
 
+	if p.configured {
+		return
+	}
+
 	var (
 		url   string
 		token string


### PR DESCRIPTION
If we don't return when there's an error, we end up adding incorrect (empty) state objects to the state. That's not what we want to do. 

Still not really sure if these should be errors or warnings.