### PR TITLE
Fix delete drift detection

### DIFF
--- a/internal/provider/product_resource.go
+++ b/internal/provider/product_resource.go
@@ -153,6 +153,9 @@ func (r productResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 		data.Name = types.String{Value: apiResp.JSON200.Name}
 		data.Description = types.String{Value: apiResp.JSON200.Description}
 		data.ProductTypeId = types.Int64{Value: int64(apiResp.JSON200.ProdType)}
+	} else if apiResp.StatusCode() == 404 {
+		resp.State.RemoveResource(ctx)
+		return
 	} else {
 		body, _ := ioutil.ReadAll(apiResp.HTTPResponse.Body)
 

--- a/internal/provider/product_resource_test.go
+++ b/internal/provider/product_resource_test.go
@@ -1,10 +1,15 @@
 package provider
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccProductResource(t *testing.T) {
@@ -41,6 +46,43 @@ func TestAccProductResource(t *testing.T) {
 	})
 }
 
+func TestAccProductResourceDeleteDrift(t *testing.T) {
+	name := fmt.Sprintf("dox-delete-%s", resource.UniqueId())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccProductResourceConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("defectdojo_product.test", "name", name),
+					resource.TestCheckResourceAttr("defectdojo_product.test", "description", "test"),
+					resource.TestCheckResourceAttr("defectdojo_product.test", "product_type_id", "1"),
+				),
+			},
+			// Delete the underlying resource and see that it detects it has been deleted
+			{
+				ExpectNonEmptyPlan: true,
+				Config:             testAccProductResourceConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDeleteResourceOutsideTerraform("defectdojo_product.test"),
+				),
+			},
+			{
+				Config: testAccProductResourceConfig(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("defectdojo_product.test", "name", name),
+					resource.TestCheckResourceAttr("defectdojo_product.test", "description", "test"),
+					resource.TestCheckResourceAttr("defectdojo_product.test", "product_type_id", "1"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 func testAccProductResourceConfig(name string) string {
 	return fmt.Sprintf(`
 provider "defectdojo" {}
@@ -50,4 +92,41 @@ resource "defectdojo_product" "test" {
   product_type_id = 1
 }
 `, name)
+}
+
+func testAccDeleteResourceOutsideTerraform(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// retrieve the resource by name from state
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("ID is not set")
+		}
+
+		// retrieve the client from the test provider
+		client, err := newClient(context.Background(), os.Getenv("DEFECTDOJO_BASEURL"), os.Getenv("DEFECTDOJO_APIKEY"), os.Getenv("DEFECTDOJO_USERNAME"), os.Getenv("DEFECTDOJO_PASSWORD"))
+		if err != nil {
+			return err
+		}
+
+		i, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		resp, err := client.ProductsDestroy(context.Background(), i)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode != 204 {
+			return fmt.Errorf("bad status code deleting the resource: %d", resp.StatusCode)
+		}
+
+		tflog.Debug(context.Background(), fmt.Sprintf("Deleted resource, ID: %d", i))
+
+		return nil
+	}
 }

--- a/internal/provider/product_type_resource.go
+++ b/internal/provider/product_type_resource.go
@@ -144,6 +144,9 @@ func (r productTypeResource) Read(ctx context.Context, req tfsdk.ReadResourceReq
 	if apiResp.StatusCode() == 200 {
 		data.Name = types.String{Value: apiResp.JSON200.Name}
 		data.Description = types.String{Value: *apiResp.JSON200.Description}
+	} else if apiResp.StatusCode() == 404 {
+		resp.State.RemoveResource(ctx)
+		return
 	} else {
 		body, _ := ioutil.ReadAll(apiResp.HTTPResponse.Body)
 


### PR DESCRIPTION
When we receive a 404 from the API for something in state, that's not an error, it's just "delete drift", i.e. something has been deleted outside of terraform. So we remove it from the state instead of erroring.