### PR TITLE
Refactor resources to reduce code duplication

### DIFF
--- a/docs/resources/product_type.md
+++ b/docs/resources/product_type.md
@@ -24,8 +24,11 @@ resource "defectdojo_product_type" "example" {
 
 ### Required
 
-- `description` (String) The description of the Product Type
 - `name` (String) The name of the Product Type
+
+### Optional
+
+- `description` (String) The description of the Product Type
 
 ### Read-Only
 

--- a/internal/provider/product_resource.go
+++ b/internal/provider/product_resource.go
@@ -3,15 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"strconv"
 
 	dd "github.com/doximity/defect-dojo-client-go"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type productResourceType struct{}
@@ -53,7 +49,10 @@ func (t productResourceType) NewResource(ctx context.Context, in tfsdk.Provider)
 	provider, diags := convertProviderType(in)
 
 	return productResource{
-		provider: provider,
+		terraformResource: terraformResource{
+			provider:     provider,
+			dataProvider: productDataProvider{},
+		},
 	}, diags
 }
 
@@ -64,218 +63,74 @@ type productResourceData struct {
 	Id            types.String `tfsdk:"id"`
 }
 
+type productDefectdojoResource struct {
+	dd.Product
+}
+
+func (ddr *productDefectdojoResource) createApiCall(ctx context.Context, p provider) (int, []byte, error) {
+	reqBody := dd.ProductsCreateJSONRequestBody(ddr.Product)
+	apiResp, err := p.client.ProductsCreateWithResponse(ctx, reqBody)
+	if apiResp.JSON201 != nil {
+		ddr.Product = *apiResp.JSON201
+	}
+
+	return apiResp.StatusCode(), apiResp.Body, err
+}
+
+func (ddr *productDefectdojoResource) readApiCall(ctx context.Context, p provider, idNumber int) (int, []byte, error) {
+	apiResp, err := p.client.ProductsRetrieveWithResponse(ctx, idNumber, &dd.ProductsRetrieveParams{})
+	if apiResp.JSON200 != nil {
+		ddr.Product = *apiResp.JSON200
+	}
+
+	return apiResp.StatusCode(), apiResp.Body, err
+}
+
+func (ddr *productDefectdojoResource) updateApiCall(ctx context.Context, p provider, idNumber int) (int, []byte, error) {
+	reqBody := dd.ProductsUpdateJSONRequestBody(ddr.Product)
+	apiResp, err := p.client.ProductsUpdateWithResponse(ctx, idNumber, reqBody)
+	if apiResp.JSON200 != nil {
+		ddr.Product = *apiResp.JSON200
+	}
+	return apiResp.StatusCode(), apiResp.Body, err
+}
+
+func (ddr *productDefectdojoResource) deleteApiCall(ctx context.Context, p provider, idNumber int) (int, []byte, error) {
+	apiResp, err := p.client.ProductsDestroyWithResponse(ctx, idNumber)
+	return apiResp.StatusCode(), apiResp.Body, err
+}
+
 type productResource struct {
-	provider provider
+	terraformResource
 }
 
-func (r productResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+type productDataProvider struct{}
+
+func (r productDataProvider) getData(ctx context.Context, getter dataGetter) (terraformResourceData, diag.Diagnostics) {
 	var data productResourceData
-
-	diags := req.Config.Get(ctx, &data)
-	resp.Diagnostics.Append(diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	apiResp, err := r.provider.client.ProductsCreateWithResponse(ctx, dd.ProductsCreateJSONRequestBody{
-		ProdType:    int(data.ProductTypeId.Value),
-		Description: data.Description.Value,
-		Name:        data.Name.Value,
-	})
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Creating Resource",
-			fmt.Sprintf("%s", err))
-		return
-	}
-
-	if apiResp.StatusCode() == 201 {
-		data.Id = types.String{Value: fmt.Sprint(apiResp.JSON201.Id)}
-		data.Name = types.String{Value: apiResp.JSON201.Name}
-		data.Description = types.String{Value: apiResp.JSON201.Description}
-		data.ProductTypeId = types.Int64{Value: int64(apiResp.JSON201.ProdType)}
-	} else {
-		body, _ := ioutil.ReadAll(apiResp.HTTPResponse.Body)
-
-		resp.Diagnostics.AddError(
-			"API Error Creating Resource",
-			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
-				fmt.Sprintf("\n\nbody:\n\n%s", body),
-		)
-		return
-	}
-
-	// write logs using the tflog package
-	// see https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log/tflog
-	// for more information
-	tflog.Trace(ctx, "created a product")
-
-	diags = resp.State.Set(ctx, &data)
-	resp.Diagnostics.Append(diags...)
+	diags := getter.Get(ctx, &data)
+	return &data, diags
 }
 
-func (r productResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
-	var data productResourceData
-
-	diags := req.State.Get(ctx, &data)
-	resp.Diagnostics.Append(diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if data.Id.Null {
-		resp.Diagnostics.AddError(
-			"Could not Retrieve Resource",
-			"The Id field was null but it is required to retrieve the product")
-		return
-	}
-
-	idNumber, err := strconv.Atoi(data.Id.Value)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Could not Retrieve Resource",
-			fmt.Sprintf("Error while parsing the Product ID from state: %s", err))
-		return
-	}
-
-	apiResp, err := r.provider.client.ProductsRetrieveWithResponse(ctx, idNumber, &dd.ProductsRetrieveParams{})
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Retrieving Resource",
-			fmt.Sprintf("%s", err))
-		return
-	}
-
-	if apiResp.StatusCode() == 200 {
-		data.Name = types.String{Value: apiResp.JSON200.Name}
-		data.Description = types.String{Value: apiResp.JSON200.Description}
-		data.ProductTypeId = types.Int64{Value: int64(apiResp.JSON200.ProdType)}
-	} else if apiResp.StatusCode() == 404 {
-		resp.State.RemoveResource(ctx)
-		return
-	} else {
-		body, _ := ioutil.ReadAll(apiResp.HTTPResponse.Body)
-
-		resp.Diagnostics.AddError(
-			"API Error Retrieving Resource",
-			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
-				fmt.Sprintf("\n\nbody:\n\n%+v", body),
-		)
-		return
-	}
-
-	diags = resp.State.Set(ctx, &data)
-	resp.Diagnostics.Append(diags...)
+func (d *productResourceData) id() types.String {
+	return d.Id
 }
 
-func (r productResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
-	var data productResourceData
-
-	diags := req.Plan.Get(ctx, &data)
-	resp.Diagnostics.Append(diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if data.Id.Null {
-		resp.Diagnostics.AddError(
-			"Could not Update Resource",
-			"The Id field was null but it is required to retrieve the product")
-		return
-	}
-
-	idNumber, err := strconv.Atoi(data.Id.Value)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Could not Update Resource",
-			fmt.Sprintf("Error while parsing the Product ID from state: %s", err))
-		return
-	}
-
-	apiResp, err := r.provider.client.ProductsUpdateWithResponse(ctx, idNumber, dd.ProductsUpdateJSONRequestBody{
-		ProdType:    int(data.ProductTypeId.Value),
-		Description: data.Description.Value,
-		Name:        data.Name.Value,
-	})
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Updating Resource",
-			fmt.Sprintf("%s", err))
-		return
-	}
-
-	if apiResp.StatusCode() == 200 {
-		data.Id = types.String{Value: fmt.Sprint(apiResp.JSON200.Id)}
-		data.Name = types.String{Value: apiResp.JSON200.Name}
-		data.Description = types.String{Value: apiResp.JSON200.Description}
-		data.ProductTypeId = types.Int64{Value: int64(apiResp.JSON200.ProdType)}
-	} else {
-		body, _ := ioutil.ReadAll(apiResp.HTTPResponse.Body)
-
-		resp.Diagnostics.AddError(
-			"API Error Updating Resource",
-			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
-				fmt.Sprintf("\n\nbody:\n\n%+v", body),
-		)
-		return
-	}
-
-	diags = resp.State.Set(ctx, &data)
-	resp.Diagnostics.Append(diags...)
+func (d *productResourceData) populate(ddResource defectdojoResource) {
+	product := ddResource.(*productDefectdojoResource)
+	d.Id = types.String{Value: fmt.Sprint(product.Id)}
+	d.Name = types.String{Value: product.Name}
+	d.Description = types.String{Value: product.Description}
+	d.ProductTypeId = types.Int64{Value: int64(product.ProdType)}
 }
 
-func (r productResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
-	var data productResourceData
-
-	diags := req.State.Get(ctx, &data)
-	resp.Diagnostics.Append(diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
+func (d *productResourceData) defectdojoResource(diags *diag.Diagnostics) (defectdojoResource, error) {
+	product := dd.Product{
+		ProdType:    int(d.ProductTypeId.Value),
+		Description: d.Description.Value,
+		Name:        d.Name.Value,
 	}
-
-	if data.Id.Null {
-		resp.Diagnostics.AddError(
-			"Could not Delete Resource",
-			"The Id field was null but it is required to retrieve the product")
-		return
-	}
-
-	idNumber, err := strconv.Atoi(data.Id.Value)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Could not Delete Resource",
-			fmt.Sprintf("Error while parsing the Product ID from state: %s", err))
-		return
-	}
-
-	apiResp, err := r.provider.client.ProductsDestroy(ctx, idNumber)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Deleting Resource",
-			fmt.Sprintf("%s", err))
-		return
-	}
-
-	if apiResp.StatusCode != 204 {
-		body, _ := ioutil.ReadAll(apiResp.Body)
-
-		resp.Diagnostics.AddError(
-			"API Error Deleting Resource",
-			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode)+
-				fmt.Sprintf("\n\nbody:\n\n%+v", body),
-		)
-		return
-	}
-
-	resp.State.RemoveResource(ctx)
-}
-
-func (r productResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
+	return &productDefectdojoResource{
+		Product: product,
+	}, nil
 }

--- a/internal/provider/product_type_resource.go
+++ b/internal/provider/product_type_resource.go
@@ -3,15 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"strconv"
 
 	dd "github.com/doximity/defect-dojo-client-go"
+	"github.com/doximity/terraform-provider-defectdojo/internal/ref"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type productTypeResourceType struct{}
@@ -29,8 +26,12 @@ func (t productTypeResourceType) GetSchema(ctx context.Context) (tfsdk.Schema, d
 			},
 			"description": {
 				MarkdownDescription: "The description of the Product Type",
-				Required:            true,
+				Optional:            true,
 				Type:                types.StringType,
+				Computed:            true,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					stringDefault(""),
+				},
 			},
 			"id": {
 				Computed:            true,
@@ -48,7 +49,10 @@ func (t productTypeResourceType) NewResource(ctx context.Context, in tfsdk.Provi
 	provider, diags := convertProviderType(in)
 
 	return productTypeResource{
-		provider: provider,
+		terraformResource: terraformResource{
+			provider:     provider,
+			dataProvider: productTypeDataProvider{},
+		},
 	}, diags
 }
 
@@ -58,213 +62,74 @@ type productTypeResourceData struct {
 	Id          types.String `tfsdk:"id"`
 }
 
+type productTypeDefectdojoResource struct {
+	dd.ProductType
+}
+
+func (ddr *productTypeDefectdojoResource) createApiCall(ctx context.Context, p provider) (int, []byte, error) {
+	reqBody := dd.ProductTypesCreateJSONRequestBody(ddr.ProductType)
+	apiResp, err := p.client.ProductTypesCreateWithResponse(ctx, reqBody)
+	if apiResp.JSON201 != nil {
+		ddr.ProductType = *apiResp.JSON201
+	}
+
+	return apiResp.StatusCode(), apiResp.Body, err
+}
+
+func (ddr *productTypeDefectdojoResource) readApiCall(ctx context.Context, p provider, idNumber int) (int, []byte, error) {
+	apiResp, err := p.client.ProductTypesRetrieveWithResponse(ctx, idNumber, &dd.ProductTypesRetrieveParams{})
+	if apiResp.JSON200 != nil {
+		ddr.ProductType = *apiResp.JSON200
+	}
+
+	return apiResp.StatusCode(), apiResp.Body, err
+}
+
+func (ddr *productTypeDefectdojoResource) updateApiCall(ctx context.Context, p provider, idNumber int) (int, []byte, error) {
+	reqBody := dd.ProductTypesUpdateJSONRequestBody(ddr.ProductType)
+	apiResp, err := p.client.ProductTypesUpdateWithResponse(ctx, idNumber, reqBody)
+	if apiResp.JSON200 != nil {
+		ddr.ProductType = *apiResp.JSON200
+	}
+	return apiResp.StatusCode(), apiResp.Body, err
+}
+
+func (ddr *productTypeDefectdojoResource) deleteApiCall(ctx context.Context, p provider, idNumber int) (int, []byte, error) {
+	apiResp, err := p.client.ProductTypesDestroyWithResponse(ctx, idNumber)
+	return apiResp.StatusCode(), apiResp.Body, err
+}
+
 type productTypeResource struct {
-	provider provider
+	terraformResource
 }
 
-func (r productTypeResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+type productTypeDataProvider struct{}
+
+func (r productTypeDataProvider) getData(ctx context.Context, getter dataGetter) (terraformResourceData, diag.Diagnostics) {
 	var data productTypeResourceData
-
-	diags := req.Config.Get(ctx, &data)
-	resp.Diagnostics.Append(diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	apiResp, err := r.provider.client.ProductTypesCreateWithResponse(ctx, dd.ProductTypesCreateJSONRequestBody{
-		Description: &data.Description.Value,
-		Name:        data.Name.Value,
-	})
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Creating Resource",
-			fmt.Sprintf("%s", err))
-		return
-	}
-
-	if apiResp.StatusCode() == 201 {
-		data.Id = types.String{Value: fmt.Sprint(apiResp.JSON201.Id)}
-		data.Name = types.String{Value: apiResp.JSON201.Name}
-		data.Description = types.String{Value: *apiResp.JSON201.Description}
-	} else {
-		body, _ := ioutil.ReadAll(apiResp.HTTPResponse.Body)
-
-		resp.Diagnostics.AddError(
-			"API Error Creating Resource",
-			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
-				fmt.Sprintf("\n\nbody:\n\n%s", body),
-		)
-		return
-	}
-
-	// write logs using the tflog package
-	// see https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log/tflog
-	// for more information
-	tflog.Trace(ctx, "created a product type")
-
-	diags = resp.State.Set(ctx, &data)
-	resp.Diagnostics.Append(diags...)
+	diags := getter.Get(ctx, &data)
+	return &data, diags
 }
 
-func (r productTypeResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
-	var data productTypeResourceData
-
-	diags := req.State.Get(ctx, &data)
-	resp.Diagnostics.Append(diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	if data.Id.Null {
-		resp.Diagnostics.AddError(
-			"Could not Retrieve Resource",
-			"The Id field was null but it is required to retrieve the product type")
-		return
-	}
-
-	idNumber, err := strconv.Atoi(data.Id.Value)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Could not Retrieve Resource",
-			fmt.Sprintf("Error while parsing the Product Type ID from state: %s", err))
-		return
-	}
-
-	apiResp, err := r.provider.client.ProductTypesRetrieveWithResponse(ctx, idNumber, &dd.ProductTypesRetrieveParams{})
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Retrieving Resource",
-			fmt.Sprintf("%s", err))
-		return
-	}
-
-	if apiResp.StatusCode() == 200 {
-		data.Name = types.String{Value: apiResp.JSON200.Name}
-		data.Description = types.String{Value: *apiResp.JSON200.Description}
-	} else if apiResp.StatusCode() == 404 {
-		resp.State.RemoveResource(ctx)
-		return
-	} else {
-		body, _ := ioutil.ReadAll(apiResp.HTTPResponse.Body)
-
-		resp.Diagnostics.AddError(
-			"API Error Retrieving Resource",
-			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
-				fmt.Sprintf("\n\nbody:\n\n%+v", body),
-		)
-		return
-	}
-
-	diags = resp.State.Set(ctx, &data)
-	resp.Diagnostics.Append(diags...)
+func (d *productTypeResourceData) id() types.String {
+	return d.Id
 }
 
-func (r productTypeResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
-	var data productTypeResourceData
-
-	diags := req.Plan.Get(ctx, &data)
-	resp.Diagnostics.Append(diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
+func (d *productTypeResourceData) populate(ddResource defectdojoResource) {
+	product := ddResource.(*productTypeDefectdojoResource)
+	d.Id = types.String{Value: fmt.Sprint(product.Id)}
+	d.Name = types.String{Value: product.Name}
+	if product.Description != nil {
+		d.Description = types.String{Value: *product.Description}
 	}
-
-	if data.Id.Null {
-		resp.Diagnostics.AddError(
-			"Could not Update Resource",
-			"The Id field was null but it is required to retrieve the product")
-		return
-	}
-
-	idNumber, err := strconv.Atoi(data.Id.Value)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Could not Update Resource",
-			fmt.Sprintf("Error while parsing the Product Type ID from state: %s", err))
-		return
-	}
-
-	apiResp, err := r.provider.client.ProductTypesUpdateWithResponse(ctx, idNumber, dd.ProductTypesUpdateJSONRequestBody{
-		Description: &data.Description.Value,
-		Name:        data.Name.Value,
-	})
-
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Updating Resource",
-			fmt.Sprintf("%s", err))
-		return
-	}
-
-	if apiResp.StatusCode() == 200 {
-		data.Id = types.String{Value: fmt.Sprint(apiResp.JSON200.Id)}
-		data.Name = types.String{Value: apiResp.JSON200.Name}
-		data.Description = types.String{Value: *apiResp.JSON200.Description}
-	} else {
-		body, _ := ioutil.ReadAll(apiResp.HTTPResponse.Body)
-
-		resp.Diagnostics.AddError(
-			"API Error Updating Resource",
-			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode())+
-				fmt.Sprintf("\n\nbody:\n\n%+v", body),
-		)
-		return
-	}
-
-	diags = resp.State.Set(ctx, &data)
-	resp.Diagnostics.Append(diags...)
 }
 
-func (r productTypeResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
-	var data productTypeResourceData
-
-	diags := req.State.Get(ctx, &data)
-	resp.Diagnostics.Append(diags...)
-
-	if resp.Diagnostics.HasError() {
-		return
+func (d *productTypeResourceData) defectdojoResource(diags *diag.Diagnostics) (defectdojoResource, error) {
+	productType := dd.ProductType{
+		Description: ref.Of(d.Description.Value),
+		Name:        d.Name.Value,
 	}
-
-	if data.Id.Null {
-		resp.Diagnostics.AddError(
-			"Could not Delete Resource",
-			"The Id field was null but it is required to retrieve the product type")
-		return
-	}
-
-	idNumber, err := strconv.Atoi(data.Id.Value)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Could not Delete Resource",
-			fmt.Sprintf("Error while parsing the Product Type ID from state: %s", err))
-		return
-	}
-
-	apiResp, err := r.provider.client.ProductTypesDestroy(ctx, idNumber)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Deleting Resource",
-			fmt.Sprintf("%s", err))
-		return
-	}
-
-	if apiResp.StatusCode != 204 {
-		body, _ := ioutil.ReadAll(apiResp.Body)
-
-		resp.Diagnostics.AddError(
-			"API Error Deleting Resource",
-			fmt.Sprintf("Unexpected response code from API: %d", apiResp.StatusCode)+
-				fmt.Sprintf("\n\nbody:\n\n%+v", body),
-		)
-		return
-	}
-
-	resp.State.RemoveResource(ctx)
-}
-
-func (r productTypeResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
+	return &productTypeDefectdojoResource{
+		ProductType: productType,
+	}, nil
 }

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -1,0 +1,237 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type terraformResourceData interface {
+	id() types.String
+	populate(defectdojoResource)
+	defectdojoResource(diags *diag.Diagnostics) (defectdojoResource, error)
+}
+
+type defectdojoResource interface {
+	createApiCall(context.Context, provider) (int, []byte, error)
+	readApiCall(context.Context, provider, int) (int, []byte, error)
+	updateApiCall(context.Context, provider, int) (int, []byte, error)
+	deleteApiCall(context.Context, provider, int) (int, []byte, error)
+}
+type dataProvider interface {
+	getData(context.Context, dataGetter) (terraformResourceData, diag.Diagnostics)
+}
+
+type terraformResource struct {
+	provider provider
+	dataProvider
+}
+
+type dataGetter interface {
+	Get(context.Context, interface{}) diag.Diagnostics
+}
+
+func (r terraformResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+	data, diags := r.getData(ctx, req.Config)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ddResource, err := data.defectdojoResource(&resp.Diagnostics)
+	if err != nil {
+		return
+	}
+
+	statusCode, body, err := ddResource.createApiCall(ctx, r.provider)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Creating Resource",
+			fmt.Sprintf("%s", err))
+		return
+	}
+
+	if ddResource != nil {
+		data.populate(ddResource)
+	} else {
+		resp.Diagnostics.AddError(
+			"API Error Creating Resource",
+			fmt.Sprintf("Unexpected response code from API: %d", statusCode)+
+				fmt.Sprintf("\n\nbody:\n\n%s", string(body)),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, "created a JiraProductConfiguration")
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r terraformResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+	data, diags := r.getData(ctx, req.State)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.id().Null {
+		resp.Diagnostics.AddError(
+			"Could not Retrieve Resource",
+			"The Id field was null but it is required to retrieve the product")
+		return
+	}
+
+	idNumber, err := strconv.Atoi(data.id().Value)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Could not Retrieve Resource",
+			fmt.Sprintf("Error while parsing the Product ID from state: %s", err))
+		return
+	}
+
+	ddResource, err := data.defectdojoResource(&resp.Diagnostics)
+	if err != nil {
+		return
+	}
+
+	statusCode, body, err := ddResource.readApiCall(ctx, r.provider, idNumber)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Retrieving Resource",
+			fmt.Sprintf("%s", err))
+		return
+	}
+
+	if statusCode == 200 {
+		data.populate(ddResource)
+	} else if statusCode == 404 {
+		resp.State.RemoveResource(ctx)
+		return
+	} else {
+		resp.Diagnostics.AddError(
+			"API Error Retrieving Resource",
+			fmt.Sprintf("Unexpected response code from API: %d", statusCode)+
+				fmt.Sprintf("\n\nbody:\n\n%+v", string(body)),
+		)
+		return
+	}
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r terraformResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+	data, diags := r.getData(ctx, req.Plan)
+
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.id().Null {
+		resp.Diagnostics.AddError(
+			"Could not Update Resource",
+			"The Id field was null but it is required to retrieve the product")
+		return
+	}
+
+	idNumber, err := strconv.Atoi(data.id().Value)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Could not Update Resource",
+			fmt.Sprintf("Error while parsing the Product ID from state: %s", err))
+		return
+	}
+
+	ddResource, err := data.defectdojoResource(&resp.Diagnostics)
+	if err != nil {
+		return
+	}
+
+	statusCode, body, err := ddResource.updateApiCall(ctx, r.provider, idNumber)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Updating Resource",
+			fmt.Sprintf("%s", err))
+		return
+	}
+
+	if statusCode == 200 {
+		data.populate(ddResource)
+	} else {
+		resp.Diagnostics.AddError(
+			"API Error Updating Resource",
+			fmt.Sprintf("Unexpected response code from API: %d", statusCode)+
+				fmt.Sprintf("\n\nbody:\n\n%+v", string(body)),
+		)
+		return
+	}
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r terraformResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+	data, diags := r.getData(ctx, req.State)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if data.id().Null {
+		resp.Diagnostics.AddError(
+			"Could not Delete Resource",
+			"The Id field was null but it is required to retrieve the product")
+		return
+	}
+
+	idNumber, err := strconv.Atoi(data.id().Value)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Could not Delete Resource",
+			fmt.Sprintf("Error while parsing the Product ID from state: %s", err))
+		return
+	}
+
+	ddResource, err := data.defectdojoResource(&resp.Diagnostics)
+	if err != nil {
+		return
+	}
+
+	statusCode, body, err := ddResource.deleteApiCall(ctx, r.provider, idNumber)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting Resource",
+			fmt.Sprintf("%s", err))
+		return
+	}
+
+	if statusCode != 204 {
+		resp.Diagnostics.AddError(
+			"API Error Deleting Resource",
+			fmt.Sprintf("Unexpected response code from API: %d", statusCode)+
+				fmt.Sprintf("\n\nbody:\n\n%+v", string(body)),
+		)
+		return
+	}
+
+	resp.State.RemoveResource(ctx)
+}
+
+func (r jiraProductConfigurationResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
+}

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -232,6 +232,6 @@ func (r terraformResource) Delete(ctx context.Context, req tfsdk.DeleteResourceR
 	resp.State.RemoveResource(ctx)
 }
 
-func (r jiraProductConfigurationResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+func (r terraformResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
 	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
 }


### PR DESCRIPTION
Introduces a generic `terraformResource` type, with the logic for Create/Read/Update/Delete templatized so new resources only have to implement the api call itself. 