### PR TITLE
Update to self hosted GHA runner

### DIFF
--- a/.github/workflows/add-content-to-project.yml
+++ b/.github/workflows/add-content-to-project.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   add-content-to-project:
     name: "Add Content to project"
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
     steps:
       - name: "Set Issue to 'Priority = Triage Next'"
         uses: leonsteinhaeuser/project-beta-automations@v1.2.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
   # Ensure project builds before running testing matrix
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
     timeout-minutes: 5
     steps:
       - uses: actions/setup-go@v3
@@ -33,7 +33,7 @@ jobs:
       - run: go build -v .
 
   generate:
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -49,7 +49,7 @@ jobs:
   test:
     name: Terraform Provider Acceptance Tests
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: general-purpose
     timeout-minutes: 15
     strategy:
       fail-fast: false


### PR DESCRIPTION
Updating from the GHA cloud runner instance to our own self hosted runners, the cost of cloud runners is ~4x what we spend to self host.

[_Created by Sourcegraph batch change `NoHesHere/update-to-general-purpose`._](https://sourcegraph.build.dox.pub/users/NoHesHere/batch-changes/update-to-general-purpose)