### PR TITLE
Update CODEOWNERS application_security -> product_platform_identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @doximity/application_security_reviewers
+* @doximity/product_platform_identity
 
 # Infra Automation
 /.github/workflows @doximity/infra_automation_reviewers


### PR DESCRIPTION
The application_security github team is going away. Product Platform Identity team is now responsible for application security.

[_Created by Sourcegraph batch change `jeffgran-dox/appsec-codeowners`._](https://doximity.sourcegraphcloud.com/users/jeffgran-dox/batch-changes/appsec-codeowners)